### PR TITLE
ci: move TF to 1pass env injection

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  tofu_version: '1.7.1'
+  tg_version: '0.69.0'
+  ENVIRONMENT: ${{ github.ref == 'refs/heads/main' && 'prod' || 'dev' }}
+
 jobs:
   build:
     strategy:
@@ -59,14 +64,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: merge
     env:
-      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-      DIST_DIR: ${{ github.workspace }}/dist
-      ENVIRONMENT: ${{ github.ref == 'refs/heads/main' && 'prod' || 'dev' }}
-      STAGE: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || '' }}
+      TF_VAR_dist_dir: ${{ github.workspace }}/dist
+      TF_VAR_stage: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || '' }}
       TF_VAR_pages_branch: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || github.ref_name }}
-      TF_STATE_POSTGRES_CONN_STR: ${{ secrets.TF_STATE_POSTGRES_CONN_STR }}
-      VMETRICS_API_TOKEN: ${{ secrets.VMETRICS_API_TOKEN }}
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ github.ref == 'refs/heads/main' && secrets.OP_TF_PROD_ENV || secrets.OP_TF_DEV_ENV }}
+      working_dir: 'deployment'
 
     steps:
       - name: Checkout code
@@ -78,51 +80,42 @@ jobs:
           name: build-output
           path: '${{ github.workspace }}/dist'
 
-      - name: Deploy App
-        env:
-          GITHUB_APP_INSTALLATION_ID: ${{ secrets.TF_APP_INSTALLATION_ID }}
-          GITHUB_APP_ID: ${{ secrets.TF_APP_ID }}
-          GITHUB_APP_PEM_FILE: ${{ secrets.TF_APP_PEM_FILE }}
-          GITHUB_OWNER: ${{ secrets.TF_APP_GITHUB_OWNER }}
-        uses: gruntwork-io/terragrunt-action@v2
+      - name: Install 1Password CLI
+        uses: 1password/install-cli-action@v1
+
+      - name: Install Terragrunt
+        uses: eLco/setup-terragrunt@v1
         with:
-          tg_version: '0.58.12'
-          tofu_version: '1.7.1'
-          tg_dir: 'deployment/modules/'
-          tg_command: 'run-all apply'
+          terragrunt_version: ${{ env.tg_version }}
+
+      - name: 'Install OpenTofu'
+        uses: opentofu/setup-opentofu@v1
+        with:
+          tofu_version: ${{ env.tofu_version }}
+          tofu_wrapper: false
+
+      - name: Deploy All
+        working-directory: ${{ env.working_dir }}
+        run: op run --env-file=".env" -- terragrunt run-all apply --terragrunt-non-interactive
 
       - name: Deploy Backend Output
-        id: terraform-backend-output
-        uses: gruntwork-io/terragrunt-action@v2
-        with:
-          tg_version: '0.58.12'
-          tofu_version: '1.7.1'
-          tg_dir: 'deployment/modules/cloudflare/backend'
-          tg_command: 'output -json'
+        id: deploy-backend-output
+        working-directory: ${{ env.working_dir }}/modules/cloudflare/backend
+        run: |
+          echo "output=$(op run --no-masking --env-file='../../../.env' -- terragrunt output -json | jq -c .)" >> $GITHUB_OUTPUT
 
       - name: Deploy Frontend Output
-        id: terraform-frontend-output
-        uses: gruntwork-io/terragrunt-action@v2
-        with:
-          tg_version: '0.58.12'
-          tofu_version: '1.7.1'
-          tg_dir: 'deployment/modules/cloudflare/frontend'
-          tg_command: 'output -json'
-
-      - name: Output Cleaning
-        id: clean
+        id: deploy-frontend-output
+        working-directory: ${{ env.working_dir }}/modules/cloudflare/frontend
         run: |
-          TG_BACKEND_OUT=$(echo '${{ steps.terraform-backend-output.outputs.tg_action_output }}' | sed 's|%0A|\n|g ; s|%3C|<|g' | jq -c .)
-          TG_FRONTEND_OUT=$(echo '${{ steps.terraform-frontend-output.outputs.tg_action_output }}' | sed 's|%0A|\n|g ; s|%3C|<|g' | jq -c .)
-          echo "backend=$TG_BACKEND_OUT" >> $GITHUB_OUTPUT
-          echo "frontend=$TG_FRONTEND_OUT" >> $GITHUB_OUTPUT
+          echo "output=$(op run --no-masking --env-file='../../../.env' -- terragrunt output -json | jq -c .)" >> $GITHUB_OUTPUT
 
       - name: Publish Frontend to Cloudflare Pages
         uses: cloudflare/pages-action@v1
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN_PAGES_UPLOAD }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: ${{ fromJson(steps.clean.outputs.frontend).pages_project_name.value }}
+          projectName: ${{ fromJson(steps.deploy-frontend-output.outputs.output).pages_project_name.value }}
           directory: 'dist/frontend'
           branch: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || github.ref_name }}
           wranglerVersion: '3'
@@ -134,7 +127,7 @@ jobs:
           number: ${{ github.event.number }}
           body: |
             🚀 Preview deployed to:
-            - Frontend URL: https://${{ fromJson(steps.clean.outputs.frontend).immich_app_branch_subdomain.value }}
-            - Backend URL: ${{ fromJson(steps.clean.outputs.backend).data_api_url.value }}
+            - Frontend URL: https://${{ fromJson(steps.deploy-frontend-output.outputs.output).immich_app_branch_subdomain.value }}
+            - Backend URL: ${{ fromJson(steps.deploy-backend-output.outputs.output).data_api_url.value }}
           emojis: 'rocket'
           body-include: '<!-- web PR URL -->'

--- a/deployment/.env
+++ b/deployment/.env
@@ -1,0 +1,9 @@
+export TF_VAR_cloudflare_account_id="op://tf/cloudflare/account_id"
+export TF_VAR_cloudflare_api_token="op://tf/cloudflare/api_token"
+export TF_VAR_tf_state_postgres_conn_str="op://tf/tf_state/postgres_conn_str"
+export TF_VAR_vmetrics_api_token="op://tf_$ENVIRONMENT/vmetrics_write_token/token"
+export TF_VAR_github_app_installation_id="op://tf/github_app_immich_tofu/installation_id"
+export TF_VAR_github_app_id="op://tf/github_app_immich_tofu/app_id"
+export TF_VAR_github_app_pem_file="op://tf/github_app_immich_tofu/private key"
+export TF_VAR_github_owner="op://tf/github_app_immich_tofu/owner"
+export TF_VAR_env=$ENVIRONMENT

--- a/deployment/modules/cloudflare/backend/terragrunt.hcl
+++ b/deployment/modules/cloudflare/backend/terragrunt.hcl
@@ -6,33 +6,19 @@ terraform {
   }
 }
 
-include "cloudflare" {
-  path = find_in_parent_folders("cloudflare.hcl")
-}
-
 include "root" {
   path = find_in_parent_folders("root.hcl")
 }
 
 locals {
-  dist_dir    = get_env("DIST_DIR")
-  vmetrics_api_token = get_env("VMETRICS_API_TOKEN")
-  env                = get_env("ENVIRONMENT")
-  stage              = get_env("STAGE", "")
+  env                = get_env("TF_VAR_env")
+  stage              = get_env("TF_VAR_stage", "")
 }
-
-inputs = {
-  dist_dir    = local.dist_dir
-  vmetrics_api_token = local.vmetrics_api_token
-  env                = local.env
-  stage              = local.stage
-}
-
 remote_state {
   backend = "pg"
 
   config = {
-    conn_str    = get_env("TF_STATE_POSTGRES_CONN_STR")
+    conn_str    = get_env("TF_VAR_tf_state_postgres_conn_str")
     schema_name = "data_immich_app_cloudflare_backend_${local.env}${local.stage}"
   }
 }

--- a/deployment/modules/cloudflare/cloudflare.hcl
+++ b/deployment/modules/cloudflare/cloudflare.hcl
@@ -1,9 +1,0 @@
-locals {
-  cloudflare_account_id = get_env("CLOUDFLARE_ACCOUNT_ID")
-  cloudflare_api_token  = get_env("CLOUDFLARE_API_TOKEN")
-}
-
-inputs = {
-  cloudflare_account_id = local.cloudflare_account_id
-  cloudflare_api_token  = local.cloudflare_api_token
-}

--- a/deployment/modules/cloudflare/frontend/config.tf
+++ b/deployment/modules/cloudflare/frontend/config.tf
@@ -4,7 +4,7 @@ terraform {
 
   required_providers {
     cloudflare = {
-      source = "cloudflare/cloudflare"
+      source  = "cloudflare/cloudflare"
       version = "4.46.0"
     }
   }

--- a/deployment/modules/cloudflare/frontend/terragrunt.hcl
+++ b/deployment/modules/cloudflare/frontend/terragrunt.hcl
@@ -6,22 +6,13 @@ terraform {
   }
 }
 
-include "cloudflare" {
-  path = find_in_parent_folders("cloudflare.hcl")
-}
-
 include "root" {
   path = find_in_parent_folders("root.hcl")
 }
 
 locals {
-  env = get_env("ENVIRONMENT")
-  stage = get_env("STAGE", "")
-}
-
-inputs = {
-  env = local.env
-  stage = local.stage
+  env = get_env("TF_VAR_env")
+  stage = get_env("TF_VAR_stage", "")
 }
 
 dependencies {
@@ -32,7 +23,7 @@ remote_state {
   backend = "pg"
 
   config = {
-    conn_str = get_env("TF_STATE_POSTGRES_CONN_STR")
+    conn_str = get_env("TF_VAR_tf_state_postgres_conn_str")
     schema_name = "data_immich_app_cloudflare_frontend_${local.env}${local.stage}"
   }
 }

--- a/deployment/modules/github/providers.tf
+++ b/deployment/modules/github/providers.tf
@@ -1,3 +1,8 @@
 provider "github" {
-  app_auth {}
+  app_auth {
+    id              = var.github_app_id
+    installation_id = var.github_app_installation_id
+    pem_file        = var.github_app_pem_file
+  }
+  owner = var.github_owner
 }

--- a/deployment/modules/github/terragrunt.hcl
+++ b/deployment/modules/github/terragrunt.hcl
@@ -17,8 +17,8 @@ dependencies {
 }
 
 locals {
-  env = get_env("ENVIRONMENT")
-  stage = get_env("STAGE", "")
+  env = get_env("TF_VAR_env")
+  stage = get_env("TF_VAR_stage", "")
 }
 
 inputs = {
@@ -30,7 +30,7 @@ remote_state {
   backend = "pg"
 
   config = {
-    conn_str = get_env("TF_STATE_POSTGRES_CONN_STR")
+    conn_str = get_env("TF_VAR_tf_state_postgres_conn_str")
     schema_name = "data_immich_app_github_org_${local.env}${local.stage}"
   }
 }

--- a/deployment/modules/github/variables.tf
+++ b/deployment/modules/github/variables.tf
@@ -1,5 +1,10 @@
 variable "tf_state_postgres_conn_str" {}
 
+variable "github_app_id" {}
+variable "github_app_installation_id" {}
+variable "github_app_pem_file" {}
+variable "github_owner" {}
+
 variable "env" {}
 variable "stage" {
   default = ""

--- a/deployment/root.hcl
+++ b/deployment/root.hcl
@@ -1,5 +1,5 @@
 locals {
-  tf_state_postgres_conn_str = get_env("TF_STATE_POSTGRES_CONN_STR")
+  tf_state_postgres_conn_str = get_env("TF_VAR_tf_state_postgres_conn_str")
 }
 
 remote_state {


### PR DESCRIPTION
This lays down a template for creating preview environments with 1pass secrets and extracting secrets.

It also removes the horrendous output cleaning we had to do previously by removing the terragrunt github action.