### PR TITLE
fix: github graph reactivity

### DIFF
--- a/frontend/src/lib/services/api.svelte.ts
+++ b/frontend/src/lib/services/api.svelte.ts
@@ -10,17 +10,17 @@ type GithubReportData = Array<[number, number]>;
 type GithubDataRecord = [DateTime, number];
 
 type GithubData = {
-  issues: GithubDataRecord[];
-  pullRequests: GithubDataRecord[];
-  stars: GithubDataRecord[];
-  discussions: GithubDataRecord[];
+  issues?: GithubDataRecord[];
+  pullRequests?: GithubDataRecord[];
+  stars?: GithubDataRecord[];
+  discussions?: GithubDataRecord[];
 };
 
 export const githubData = $state<GithubData>({
-  stars: [],
-  issues: [],
-  pullRequests: [],
-  discussions: [],
+  stars: undefined,
+  issues: undefined,
+  pullRequests: undefined,
+  discussions: undefined,
 });
 
 const asTimestamp = ([timestamp, value]: [number, number]) =>

--- a/frontend/src/routes/+layout.ts
+++ b/frontend/src/routes/+layout.ts
@@ -1,0 +1,1 @@
+export const ssr = false;

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import '$lib/app.css';
   import GithubGraph from '$lib/components/graphs/github-graph.svelte';
-  import { githubData } from '$lib/services/api.svelte';
+  import { githubData, loadGithubData } from '$lib/services/api.svelte';
   import { Card, CardBody, CardHeader, CardTitle, Container, Heading, HStack, Icon, Text } from '@immich/ui';
   import { mdiBugOutline, mdiMessageOutline, mdiSourceBranch, mdiStarOutline } from '@mdi/js';
   import uPlot from 'uplot';
@@ -17,6 +17,8 @@
       key: 'sync',
     },
   };
+
+  void loadGithubData();
 </script>
 
 <Container size="giant" center>

--- a/frontend/src/routes/+page.ts
+++ b/frontend/src/routes/+page.ts
@@ -1,9 +1,0 @@
-import { loadGithubData } from '$lib/services/api.svelte';
-
-export const ssr = false;
-
-export const load = async () => {
-  await loadGithubData();
-
-  return {};
-};


### PR DESCRIPTION
Allows us to use the reactivity in `loadGithubData`. Thus, we can also use real-time updates now. More importantly, the user does not see a white blank page waiting for the data to load